### PR TITLE
Update to Peru-Bolivia Confederation Formation

### DIFF
--- a/HFM Expanded/decisions/Peru-Bolivia Confederation.txt
+++ b/HFM Expanded/decisions/Peru-Bolivia Confederation.txt
@@ -347,6 +347,7 @@ political_decisions = {
 				tag = PEU
 				tag = SPU
 				tag = BOL
+				tag = CHL
 			}
 			NOT = { exists = PBC }
 		}
@@ -367,6 +368,11 @@ political_decisions = {
 				is_sphere_leader_of = BOL
 				tag = BOL
 				owns = 2313
+			}
+			OR = {
+				is_sphere_leader_of = CHL
+				tag = CHL
+				owns = 2324
 			}
 			nationalism_n_imperialism = 1
 			is_greater_power = yes


### PR DESCRIPTION
Given Chile the option to form the Confederation. Chile now required in the formation of the Confederation.