### PR TITLE
Fix the Sonderbund war and late game cement

### DIFF
--- a/HFM Expanded/events/FlavourMod_EuropeOther.txt
+++ b/HFM Expanded/events/FlavourMod_EuropeOther.txt
@@ -29,7 +29,7 @@ country_event = {
 	option = {
 		name = "EVT99800OPTA"
 		prestige = -10
-		remove_country_modifier = neutrality
+		remove_country_modifier = neutrality_modifier
 		3250 = { add_core = SDB secede_province = SDB }
 		609 = { add_core = SDB secede_province = SDB }
 		3272 = { add_core = SDB secede_province = SDB }

--- a/HFM Expanded/technologies/commerce_tech.txt
+++ b/HFM Expanded/technologies/commerce_tech.txt
@@ -5,6 +5,7 @@ private_banks = {
     cost = 3600
 
     tax_eff = 5
+    activate_building = cement_factory
 
     ai_chance = {
         factor = 4

--- a/HFM Expanded/technologies/commerce_tech.txt
+++ b/HFM Expanded/technologies/commerce_tech.txt
@@ -347,6 +347,7 @@ early_classical_theory_and_critique = {
     year = 1836
     cost = 3600
 
+    activate_building = lumber_mill 
     factory_input = -0.01
     ai_chance = {
         factor = 1


### PR DESCRIPTION
Fix the Sonderbund war (#6) by correcting "neutrality" to "neutrality_modifier" and fixed cement problem by readding their factories to "Private Banks". Probably went unnoticed for so long because unless you're in a large pop industrializing nation that can build factories, artisans and factories already in the game make up for most of the missing cement.

EDIT: Just realized this _was_ noticed in #4 , I'll fix lumber mills as well.